### PR TITLE
Bugfix for Template parameter being null and plain-js compatbility

### DIFF
--- a/unishox2.js
+++ b/unishox2.js
@@ -1335,7 +1335,7 @@ function unishox2_decompress_simple(input, len) {
   return unishox2_decompress(input, len, null, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES);
 }
 
-if("module" in window){
+if (typeof module !== "undefined" && module.exports && typeof window === 'undefined'){
   module.exports = {unishox2_compress, unishox2_compress_simple,
                    unishox2_decompress, unishox2_decompress_simple,
                      USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES};

--- a/unishox2.js
+++ b/unishox2.js
@@ -1335,6 +1335,8 @@ function unishox2_decompress_simple(input, len) {
   return unishox2_decompress(input, len, null, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES);
 }
 
-module.exports = {unishox2_compress, unishox2_compress_simple,
+if("module" in window){
+  module.exports = {unishox2_compress, unishox2_compress_simple,
                    unishox2_decompress, unishox2_decompress_simple,
-                   USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES};
+                     USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES};
+}

--- a/unishox2.js
+++ b/unishox2.js
@@ -1335,7 +1335,7 @@ function unishox2_decompress_simple(input, len) {
   return unishox2_decompress(input, len, null, USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES);
 }
 
-if (typeof module !== "undefined" && module.exports && typeof window === 'undefined'){
+if (typeof module !== "undefined" && module.exports){
   module.exports = {unishox2_compress, unishox2_compress_simple,
                    unishox2_decompress, unishox2_decompress_simple,
                      USX_HCODES_DFLT, USX_HCODE_LENS_DFLT, USX_FREQ_SEQ_DFLT, USX_TEMPLATES};

--- a/unishox2.js
+++ b/unishox2.js
@@ -19,6 +19,8 @@
  
 var USX_HCODES_DFLT = new Uint8Array([0x00, 0x40, 0x80, 0xC0, 0xE0]);
 var USX_HCODE_LENS_DFLT = new Uint8Array([2, 2, 2, 3, 3]);
+var USX_HCODES_ALPHA_NUM_SYM_ONLY = new Uint8Array([0x00, 0x80, 0xC0, 0x00, 0x00]);
+var USX_HCODE_LENS_ALPHA_NUM_SYM_ONLY = new Uint8Array([1, 2, 2, 0, 0]);
 var USX_FREQ_SEQ_DFLT = ["\": \"", "\": ", "</", "=\"", "\":\"", "://"];
 var USX_TEMPLATES = ["tfff-of-tfTtf:rf:rf.fffZ", "tfff-of-tf", "(fff) fff-ffff", "tf:rf:rf", 0];
 
@@ -1212,7 +1214,7 @@ function unishox2_decompress(input, len, out_arr, usx_hcodes, usx_hcode_lens, us
             [rem, bit_no] = readCount(input, bit_no, len);
             if (rem < 0)
               break;
-            if (usx_templates[idx] == null)
+            if (usx_templates == null || usx_templates[idx] == null)
               break;
             var tlen = usx_templates[idx].length;
             if (rem > tlen)


### PR DESCRIPTION
Trying to decompress with the templates parameter being null would result in an exception because the algorithm checks for template[idx] == null but not template == null. This is fixed in the first commit.

Additionally implemented are 
- a check whether the module-api exists to allow using unishox2.js directly without node, in plain javascript-fashion. 
- the HCODE parameters for ALPHA_NUM_SYM_ONLY as they're defined in the c-library.
 